### PR TITLE
Rewrite rolling titles AMP HTML to HTML5 [ci skip]

### DIFF
--- a/credits/index.html
+++ b/credits/index.html
@@ -2,7 +2,6 @@
 <html amp lang="en">
 <head>
   <meta charset="utf-8">
-  <script async src="https://cdn.ampproject.org/v0.js"></script>
 
   <title>Credits - StoreCore™</title>
   <link rel="canonical" href="http://storecore.io/credits/">
@@ -13,7 +12,7 @@
   <link href="https://fonts.googleapis.com/css?family=Roboto:300&amp;text=Core" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400" rel="stylesheet">
 
-  <style amp-custom>
+  <style>
     html, body {
       cursor: default;
       box-sizing: border-box;
@@ -106,8 +105,16 @@
       text-transform: none;
     }
   </style>
-  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-  <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    ga('create', 'UA-80202349-1', 'auto');
+    ga('send', 'pageview');
+  </script>
+
 </head>
 <body>
   <div class='wrapper'>
@@ -217,22 +224,5 @@
 
     </article>
   </div>
-
-  <amp-analytics type="googleanalytics" id="analyticsPageview">
-    <script type="application/json">
-      {
-        "vars": {
-          "account": "UA-80202349-1"
-        },
-        "triggers": {
-          "trackPageview": {
-            "on": "visible",
-            "request": "pageview"
-          }
-        }
-      }
-    </script>
-  </amp-analytics>
-
 </body>
 </html>


### PR DESCRIPTION
The rolling titles of the StoreCore Credits page at http://storecore.io/credits/ were no longer rolling. A change in how AMP handles CSS animations seems to be the most plausible cause. This fix replaces AMP HTML with plain HTML5, which for now fixes the missing animation effect.